### PR TITLE
Use "Trusted Publishing" for NPM `publish`

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -22,14 +22,18 @@ jobs:
   publish-npm:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # required for OIDC Trusted Publishing (and provenance)
+      contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 18
+          node-version: 24
           registry-url: https://registry.npmjs.org/
       - run: npm ci
-      - run: npm run build --if-present
+      - run: npm install -g npm@latest # ensure npm >= 11.5.1 for OIDC publishing
       - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+        # No NODE_AUTH_TOKEN: authentication is handled via OIDC Trusted Publishing,
+        # configured for this repo + workflow at npmjs.com. Publishing this way also
+        # attaches a signed provenance attestation automatically.


### PR DESCRIPTION
Replace the long-lived npm_token (which expired and broke the last release) with OIDC Trusted Publishing: grant id-token: write, run on Node 24 with npm >= 11.5.1, and drop NODE_AUTH_TOKEN. Auth is now minted per-run and publishes carry a signed provenance attestation.