### PR TITLE
Anchor distortion windows at construction (fix cross-midnight + sparse-read bugs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,24 @@ clock.referenceTimeInMillis // returns epochMillis for 10:00am
 clock.relativeTimeInMillis // returns epochMillis for 11:00am
 clock.referenceTimeInMillis // returns epochMillis for 11:00am
 ```
+## How windows are scheduled
+
+A few things worth knowing about *when* your distortions actually fire:
+
+- **Windows are anchored when the `Clock` is constructed.** Each distortion's window resolves
+  *once* — to its current-or-next occurrence as of the moment you call `new Clock(...)` — and
+  stays pinned there for the life of that clock. So build the `Clock` at (or before) the window
+  you intend to bend. If a window has already fully passed at construction time, it resolves to
+  its *next* occurrence instead.
+- **Windows are one-shot.** A window distorts a single occurrence, not "every night" — which is
+  fine, because you'll only get away with this once a year on Christmas morning anyway. Want the
+  next occurrence? Spin up a new `Clock`.
+- **Overnight windows work.** A window whose end-of-day is earlier than its start (e.g.
+  `{ hour: 23 }` → `03:00`) spans midnight and keeps distorting straight across the date boundary.
+- **The offset is cumulative.** Time lost to a dilation persists until a later compression pays it
+  back. Polling matters not: read the clock once or a thousand times, eagerly or after idling for
+  days — each window is integrated exactly once.
+
 ## Roadmap (as of August 2022)
 
 There are plenty of improvements I can imagine implementing, but I need some time living with the API as it currently exists before going further. This is my top-o-the-head, tip-o-the-tongue wishlist:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clockblocker",
-  "version": "0.0.1",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "clockblocker",
-      "version": "0.0.1",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@js-temporal/polyfill": "^0.4.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clockblocker",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A Typescript library for warping the very fabric of space-time, or for building deceitful clocks.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/Clock.ts
+++ b/src/Clock.ts
@@ -1,12 +1,16 @@
 import RelativeTimeDistortion from './RelativeTimeDistortion';
-import { TimeWindowComparison } from './TimeWindow';
 
 export default class Clock {
   private _offset = 0;
   private _lastCheck: number;
+  // The run anchor pins every window to a single fixed [start, end) occurrence, captured
+  // once at construction. Windows no longer re-resolve to "today" on each read, which is
+  // what made overnight (cross-midnight) and sparsely-polled clocks drop their distortions.
+  private _runAnchor: number;
   private _timeDistortions: Array<RelativeTimeDistortion>;
   constructor(timeDistortions: Array<RelativeTimeDistortion> = []) {
     this._lastCheck = this.referenceTimeInMillis;
+    this._runAnchor = this._lastCheck;
     this._timeDistortions = timeDistortions;
   }
 
@@ -17,14 +21,14 @@ export default class Clock {
   get offset() {
     const now = this.referenceTimeInMillis;
     this._offset = this._timeDistortions.reduce((offset, distortion) => {
-      const window = distortion.getTimeWindow();
-      if (window.compareWithinWindow(now) === TimeWindowComparison.EARLIER) return offset;
-      if (window.compareWithinWindow(this._lastCheck) === TimeWindowComparison.LATER) return offset;
+      const { startMs, endMs } = distortion.getTimeWindow().resolveAt(this._runAnchor);
+      if (now < startMs) return offset; // window has not started yet
+      if (this._lastCheck >= endMs) return offset; // window already finished before last check
       const timeSinceLastCheck = now - this._lastCheck;
-      const windowOffset = Math.max(0, this._lastCheck - window.windowStartInMillis);
+      const windowOffset = Math.max(0, this._lastCheck - startMs);
       const windowLength = Math.min(
-        window.durationInMillis,
-        Math.min(now - window.windowStartInMillis, timeSinceLastCheck, window.windowEndInMillis - this._lastCheck),
+        endMs - startMs,
+        Math.min(now - startMs, timeSinceLastCheck, endMs - this._lastCheck),
       );
       return offset + distortion.getElapsedTimeInMillis(windowOffset, windowLength);
     }, this._offset);

--- a/src/ClockTime.ts
+++ b/src/ClockTime.ts
@@ -37,6 +37,12 @@ export default class ClockTime {
     return this.forPlainDateInMillis(date, ianaTimeZoneId);
   }
 
+  // Resolve this wall-clock time on an arbitrary calendar date (not just today/tomorrow),
+  // so an anchored window can search occurrences across neighbouring days.
+  forDateInMillis(date: Temporal.PlainDate, ianaTimeZoneId = `UTC`) {
+    return this.forPlainDateInMillis(date, ianaTimeZoneId);
+  }
+
   add(duration: Temporal.DurationLike) {
     return new ClockTime(this._clockTime.add(duration));
   }

--- a/src/TimeWindow.ts
+++ b/src/TimeWindow.ts
@@ -1,3 +1,4 @@
+import { Temporal } from '@js-temporal/polyfill';
 import ClockTime, { ClockTimeComparison } from './ClockTime';
 
 export enum TimeWindowComparison {
@@ -5,15 +6,31 @@ export enum TimeWindowComparison {
   WITHIN = 0,
   LATER = 1,
 }
+
+// 'none' = one-shot: the window resolves to a single fixed occurrence. 'daily' (recurring)
+// is a deferred opt-in and is not yet implemented; the field reserves the seam.
+export type WindowRecurrence = 'none' | 'daily';
+
+export interface ResolvedWindow {
+  startMs: number;
+  endMs: number;
+}
+
 export default class TimeWindow {
   private start: ClockTime;
   private end: ClockTime;
   private _timeZone: string;
+  private _recurrence: WindowRecurrence;
 
-  constructor(start: ClockTime, end: ClockTime, timeZone = `UTC`) {
+  constructor(start: ClockTime, end: ClockTime, timeZone = `UTC`, recurrence: WindowRecurrence = `none`) {
     this.start = start;
     this.end = end;
     this._timeZone = timeZone;
+    this._recurrence = recurrence;
+  }
+
+  private get wrapsMidnight() {
+    return this.end.compare(this.start) === ClockTimeComparison.EARLIER;
   }
 
   get windowStartInMillis() {
@@ -21,7 +38,7 @@ export default class TimeWindow {
   }
 
   get windowEndInMillis() {
-    if (this.end.compare(this.start) === ClockTimeComparison.EARLIER) {
+    if (this.wrapsMidnight) {
       return this.end.forTomorrowInMillis(this._timeZone);
     }
     return this.end.forTodayInMillis(this._timeZone);
@@ -31,8 +48,36 @@ export default class TimeWindow {
     return this.windowEndInMillis - this.windowStartInMillis;
   }
 
+  // Resolve to a single fixed [start, end) occurrence relative to a fixed anchor instant.
+  // One-shot semantics: pick the occurrence that contains the anchor, otherwise the next
+  // upcoming one. For a midnight-wrapping window the containing occurrence may have started
+  // on the prior calendar day (e.g. at 00:30 you are inside last night's 23:00->03:00 span),
+  // so candidates span the day before and after the anchor's date, not just the anchor's day.
+  resolveAt(anchorMs: number): ResolvedWindow {
+    const wraps = this.wrapsMidnight;
+    const anchorDate = Temporal.Instant.fromEpochMilliseconds(anchorMs)
+      .toZonedDateTimeISO(this._timeZone)
+      .toPlainDate();
+
+    const occurrences = [-1, 0, 1]
+      .map((dayDelta) => {
+        const startDate = anchorDate.add({ days: dayDelta });
+        const endDate = wraps ? startDate.add({ days: 1 }) : startDate;
+        return {
+          startMs: this.start.forDateInMillis(startDate, this._timeZone),
+          endMs: this.end.forDateInMillis(endDate, this._timeZone),
+        };
+      })
+      .sort((a, b) => a.startMs - b.startMs);
+
+    const current = occurrences.find((o) => o.startMs <= anchorMs && anchorMs < o.endMs);
+    if (current) return current;
+    // The day-after occurrence always starts strictly after the anchor, so a next exists.
+    return occurrences.find((o) => o.startMs > anchorMs) ?? occurrences[occurrences.length - 1];
+  }
+
   clone() {
-    return new TimeWindow(this.start, this.end, this._timeZone);
+    return new TimeWindow(this.start, this.end, this._timeZone, this._recurrence);
   }
 
   compareWithinWindow(timeInMillis: number) {

--- a/test/Clock.test.ts
+++ b/test/Clock.test.ts
@@ -57,38 +57,53 @@ describe(`Clock class`, () => {
       expect(clock.relativeTimeInMillis).toEqual(clock.referenceTimeInMillis + offset);
     });
   });
-  // KNOWN LIMITATION: a distortion's window is described purely as a wall-clock time-of-day
-  // and is always resolved against the *current* calendar date (ClockTime.forTodayInMillis).
-  // A window that wraps past midnight (end-of-day < start-of-day) is therefore only active on
-  // the calendar day it starts; once the date rolls over, its start time is recomputed as
-  // tonight's occurrence (in the future) and the in-progress distortion silently drops out.
-  // These tests pin that behavior so the gap is visible and a future date/timezone-aware
-  // implementation has a regression target. The midnight scenario is exactly the README's
-  // overnight use case, so this matters in practice.
-  describe(`midnight-wrapping window (known limitation)`, () => {
+  // A window is now pinned once, at clock construction, to a single fixed [start, end)
+  // occurrence (one-shot semantics) instead of being re-resolved to the *current* calendar
+  // date on every read. A window that wraps past midnight (end-of-day < start-of-day) is
+  // therefore active continuously across the midnight boundary, rather than silently
+  // dropping its in-progress distortion once the date rolls over. This is exactly the
+  // README's overnight use case. These were previously pinned as a known limitation; they
+  // now assert the fixed behavior.
+  describe(`midnight-wrapping window (resolves continuously across midnight)`, () => {
     const hour = 1000 * 60 * 60;
     const minute = 1000 * 60;
     // 11pm start, runs at half speed for a 4h reference window => ends 3am the next day.
-    const buildClock = () => new Clock([new ConstantTimeDilation({ hour: 23 }, { hours: 2 }, { hours: 4 })]);
+    // Constructing the clock at 10pm pins the one-shot window to tonight's 23:00->03:00.
+    const buildClockAt = (constructMs: number) => {
+      jest.setSystemTime(constructMs);
+      return new Clock([new ConstantTimeDilation({ hour: 23 }, { hours: 2 }, { hours: 4 })]);
+    };
 
-    it('distorts correctly before midnight, on the day the window starts', () => {
-      const clock = buildClock();
-      jest.setSystemTime(23 * hour); // 11:00pm, window start
-      clock.relativeTimeInMillis; // prime lastCheck at the window start
-
+    it('distorts before midnight, on the evening the window starts', () => {
+      const clock = buildClockAt(22 * hour); // 10:00pm, before the window
       jest.setSystemTime(23 * hour + 30 * minute); // 11:30pm, 30 real minutes into the window
       // Half speed => only 15 fake minutes have passed; the clock is 15 minutes behind.
       expect(clock.relativeTimeInMillis - clock.referenceTimeInMillis).toEqual(-15 * minute);
     });
 
-    it('does NOT distort after midnight, even though 00:30 is inside the 23:00->03:00 window', () => {
-      jest.setSystemTime(24 * hour + 30 * minute); // 12:30am the following day
-      const clock = buildClock();
+    it('keeps distorting AFTER midnight (the old cross-midnight drop-out, now fixed)', () => {
+      const clock = buildClockAt(22 * hour); // 10:00pm, before the window
+      jest.setSystemTime(24 * hour + 30 * minute); // 12:30am, 90 real minutes into the window
+      // 23:00 -> 00:30 is 90 real minutes at half speed => 45 fake minutes => 45 min behind.
+      // Pre-fix this read fell outside the re-anchored "today" window and lost nothing.
+      expect(clock.relativeTimeInMillis - clock.referenceTimeInMillis).toEqual(-45 * minute);
+    });
+  });
 
-      // The window *should* still be active here, but because its start is re-resolved to the
-      // current (already-past-midnight) date, it is treated as not-yet-started and no
-      // distortion is applied. Documents the bug rather than endorsing it.
-      expect(clock.relativeTimeInMillis).toEqual(clock.referenceTimeInMillis);
+  // The window must be integrated even if the clock is polled sparsely: read once before it,
+  // idle straight through it (and past midnight), then read once after. Pre-fix the window
+  // re-resolved to the read-time "today" -- sitting in the future when read days later -- so
+  // the whole excursion was skipped and nothing was lost.
+  describe(`sparse reads across a fully-elapsed window`, () => {
+    const hour = 1000 * 60 * 60;
+
+    it('integrates the window exactly once even when idle for days between reads', () => {
+      const clock = new Clock([new ConstantTimeDilation({ hour: 1 }, { hours: 3 }, { hours: 6 })]); // built at midnight
+      clock.relativeTimeInMillis; // prime lastCheck before the 1am-7am window
+
+      jest.setSystemTime(3 * 24 * hour); // idle three days, well past the window
+      // The half-speed window loses exactly 3h, once -- not zero, and not three times.
+      expect(clock.relativeTimeInMillis - clock.referenceTimeInMillis).toEqual(-3 * hour);
     });
   });
   describe(`getRelativeTime`, () => {


### PR DESCRIPTION
## What & why

Distortion windows were hardwired to re-resolve to **"today"** on every read
(`TimeWindow` → `ClockTime.forTodayInMillis`), while `Clock._offset` accumulates on a
single continuous timeline. Across a calendar boundary these two models conflict, which
produced two latent correctness bugs — one already pinned in the suite as a *known
limitation* with a regression target:

- **Cross-midnight drop-out** — an overnight window (e.g. `23:00→03:00`) stopped
  distorting after midnight, because its start re-resolved to tonight's *future*
  occurrence. This is precisely the README's bedside-clock use case.
- **Sparse-read gap** — read before a window → idle through it (even for days) → read
  after, and only the read-time "today" instance was integrated; the whole excursion was
  silently skipped.

## The fix

Pin each window **once, at `Clock` construction**, to a single fixed `[start, end)`
occurrence (one-shot semantics) rather than re-resolving on every read:

- `Clock` captures a `_runAnchor` at construction and resolves every window against it.
- `TimeWindow.resolveAt(anchorMs)` returns the occurrence containing the anchor, else the
  next upcoming one — with prior-day look-back so a midnight-wrapping window's *current*
  occurrence (which may have started yesterday) is found. Legacy today-resolving getters
  are kept for backward compatibility.
- `ClockTime.forDateInMillis` resolves a wall-clock time on an arbitrary date.
- Adds a `recurrence: 'none' | 'daily'` seam (`'none'` implemented), establishing the
  anchor abstraction that the deferred multi-day / stopwatch / countdown modes build on.

## Tests

- The two previously-pinned "known limitation" cases now assert the **fixed** behavior
  (distortion continues across midnight).
- New regression coverage: cross-midnight continuity, and sparse reads integrating a
  fully-elapsed window **exactly once**.
- Full pre-existing suite passes unchanged — **48/48 green**, `tsc --noEmit` and eslint
  clean.

## Notes

- New user-observable behavior: a window now pins to its occurrence **as of when the
  `Clock` is constructed** — build the clock at/before the window you intend to bend.
  Documented in a new README "How windows are scheduled" section.
- Version bumped to **0.2.0** (minor — behavior change on a 0.x line); also corrects
  pre-existing `package-lock.json` version drift (`0.0.1` → `0.2.0`).

Refs #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
