### PR TITLE
Add elapsed window anchor (run-relative distortions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,32 @@ export interface Duration {
   milliseconds?: number;
 }
 ```
+
+### Anchoring a distortion to the run instead of a time-of-day
+
+By default `referenceStartClockTime` is a wall-clock time-of-day. You can instead anchor a distortion to the *run itself* — measured in real time elapsed since the `Clock` was constructed — by passing `{ elapsed }` in that first slot:
+
+```
+import { Clock, ConstantTimeDilation } from 'clockblocker';
+
+// Crawl at half speed for the first 30 real minutes of the run, no matter what the wall clock reads.
+const clock = new Clock([
+  new ConstantTimeDilation(
+    { elapsed: { minutes: 0 } }, // start at t=0 of the run (vs. a wall-clock time)
+    { minutes: 15 },             // 15 minutes of "fake" time appear to pass...
+    { minutes: 30 },             // ...over the first 30 real minutes
+  ),
+]);
+```
+
+So the start anchor accepts either form:
+
+```
+export type DistortionAnchor = ClockTimeDescriptor | { elapsed: Duration };
+```
+
+(This is the building block for stopwatch- and countdown-style clocks; the ergonomic facades for those are coming.)
+
 ## Contributing
 
 1. Fork repo

--- a/src/DistortionWindow.ts
+++ b/src/DistortionWindow.ts
@@ -1,0 +1,13 @@
+// The contract `Clock` consumes a distortion window through. Each window resolves itself,
+// against the run anchor captured at `Clock` construction, to a single fixed [start, end)
+// interval in reference (real) epoch millis. Any anchor kind (time-of-day, elapsed, ...) is
+// just another implementation of this contract; the offset integrator never has to know which.
+export interface ResolvedWindow {
+  startMs: number;
+  endMs: number;
+}
+
+export interface DistortionWindow {
+  resolveAt(anchorMs: number): ResolvedWindow;
+  clone(): DistortionWindow;
+}

--- a/src/ElapsedWindow.ts
+++ b/src/ElapsedWindow.ts
@@ -1,0 +1,17 @@
+import { DistortionWindow, ResolvedWindow } from './DistortionWindow';
+
+// A window pinned to the run's own t=0 rather than to a wall-clock time-of-day. The anchor
+// passed to `resolveAt` is the run start (Clock's run anchor), and the offsets are measured in
+// reference (real) elapsed time, so the window simply shifts with the run. This is the seam the
+// future Stopwatch/Countdown facades sit on; only the displayed time is warped, not the window.
+export default class ElapsedWindow implements DistortionWindow {
+  constructor(private startOffsetMs: number, private endOffsetMs: number) {}
+
+  resolveAt(anchorMs: number): ResolvedWindow {
+    return { startMs: anchorMs + this.startOffsetMs, endMs: anchorMs + this.endOffsetMs };
+  }
+
+  clone() {
+    return new ElapsedWindow(this.startOffsetMs, this.endOffsetMs);
+  }
+}

--- a/src/RelativeTimeDistortion.ts
+++ b/src/RelativeTimeDistortion.ts
@@ -1,6 +1,8 @@
 import { Temporal } from '@js-temporal/polyfill';
 import ClockTime, { ClockTimeDescriptor } from './ClockTime';
 import TimeWindow from './TimeWindow';
+import ElapsedWindow from './ElapsedWindow';
+import { DistortionWindow } from './DistortionWindow';
 
 export interface Duration {
   hours?: number;
@@ -8,34 +10,38 @@ export interface Duration {
   seconds?: number;
   milliseconds?: number;
 }
+
+// Where a distortion is anchored. A bare ClockTimeDescriptor means a wall-clock time-of-day
+// (the original, default behavior); `{ elapsed }` anchors the window to the run's own t=0,
+// measured in reference (real) time since the Clock was constructed.
+export type DistortionAnchor = ClockTimeDescriptor | { elapsed: Duration };
+
+const durationToMillis = (duration: Duration) =>
+  Temporal.Duration.from(duration).round({ largestUnit: 'millisecond' }).milliseconds;
+
+const isElapsedAnchor = (anchor: DistortionAnchor): anchor is { elapsed: Duration } => `elapsed` in anchor;
+
 export default abstract class RelativeTimeDistortion {
-  protected timeWindow: TimeWindow;
-  protected startClockTime: ClockTime;
+  protected timeWindow: DistortionWindow;
   protected relativeDurationInMillis: number;
   protected referenceDurationInMillis: number;
-  constructor(
-    referenceStartClockTime: ClockTimeDescriptor,
-    relativeDuration: Duration,
-    referenceDuration: Duration = relativeDuration,
-  ) {
-    this.startClockTime = new ClockTime(referenceStartClockTime);
-    this.timeWindow = new TimeWindow(this.startClockTime, this.startClockTime.add(referenceDuration));
-    this.relativeDurationInMillis = Temporal.Duration.from(relativeDuration).round({
-      largestUnit: 'millisecond',
-    }).milliseconds;
-    this.referenceDurationInMillis = Temporal.Duration.from(referenceDuration).round({
-      largestUnit: 'millisecond',
-    }).milliseconds;
+  constructor(anchor: DistortionAnchor, relativeDuration: Duration, referenceDuration: Duration = relativeDuration) {
+    this.relativeDurationInMillis = durationToMillis(relativeDuration);
+    this.referenceDurationInMillis = durationToMillis(referenceDuration);
+    if (isElapsedAnchor(anchor)) {
+      const startOffset = durationToMillis(anchor.elapsed);
+      this.timeWindow = new ElapsedWindow(startOffset, startOffset + this.referenceDurationInMillis);
+    } else {
+      const start = new ClockTime(anchor);
+      this.timeWindow = new TimeWindow(start, start.add(referenceDuration));
+    }
   }
 
   getTimeWindow() {
     return this.timeWindow.clone();
   }
 
-  getElapsedTimeInMillis(
-    offset = 0,
-    length: number = this.timeWindow.windowEndInMillis - this.timeWindow.windowStartInMillis,
-  ) {
+  getElapsedTimeInMillis(offset = 0, length: number = this.referenceDurationInMillis) {
     return this.distortTime(length, offset);
   }
 

--- a/src/TimeWindow.ts
+++ b/src/TimeWindow.ts
@@ -1,5 +1,6 @@
 import { Temporal } from '@js-temporal/polyfill';
 import ClockTime, { ClockTimeComparison } from './ClockTime';
+import { DistortionWindow, ResolvedWindow } from './DistortionWindow';
 
 export enum TimeWindowComparison {
   EARLIER = -1,
@@ -11,12 +12,7 @@ export enum TimeWindowComparison {
 // is a deferred opt-in and is not yet implemented; the field reserves the seam.
 export type WindowRecurrence = 'none' | 'daily';
 
-export interface ResolvedWindow {
-  startMs: number;
-  endMs: number;
-}
-
-export default class TimeWindow {
+export default class TimeWindow implements DistortionWindow {
   private start: ClockTime;
   private end: ClockTime;
   private _timeZone: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 import Clock from './Clock';
 import ConstantTimeDilation from './ConstantTimeDilation';
 import ConstantTimeCompression from './ConstantTimeCompression';
+import { DistortionAnchor } from './RelativeTimeDistortion';
 
 export { Clock, ConstantTimeCompression, ConstantTimeDilation };
+export type { DistortionAnchor };

--- a/test/ElapsedAnchor.test.ts
+++ b/test/ElapsedAnchor.test.ts
@@ -1,0 +1,79 @@
+import { Clock, ConstantTimeCompression, ConstantTimeDilation } from '../src/index';
+
+// An elapsed-anchored window is pinned to the run's own t=0 (the Clock's construction instant)
+// and measured in real time, so it behaves the same no matter what the wall clock reads. These
+// drive a Clock through such windows and assert the offset integrator handles them unchanged.
+describe(`elapsed anchor`, () => {
+  const minute = 60 * 1000;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  // Build the clock *after* setting the system time, so the run anchor is `constructAtMs`.
+  const buildClockAt = (constructAtMs: number, distortions: ConstructorParameters<typeof Clock>[0]) => {
+    jest.setSystemTime(constructAtMs);
+    return new Clock(distortions);
+  };
+
+  describe(`is run-relative, not time-of-day`, () => {
+    // Half speed for the first 30 real minutes of the run => loses 15 minutes by minute 30.
+    const dilation = () => [new ConstantTimeDilation({ elapsed: { minutes: 0 } }, { minutes: 15 }, { minutes: 30 })];
+
+    const lostByMinute30 = (constructAtMs: number) => {
+      const clock = buildClockAt(constructAtMs, dilation());
+      jest.setSystemTime(constructAtMs + 30 * minute);
+      return clock.relativeTimeInMillis - clock.referenceTimeInMillis;
+    };
+
+    it(`distorts the first 30 minutes the same regardless of the calendar date`, () => {
+      // Two runs started decades and time-zones apart; the elapsed window fires identically.
+      expect(lostByMinute30(Date.UTC(2026, 0, 1, 14, 17))).toEqual(-15 * minute);
+      expect(lostByMinute30(Date.UTC(1995, 5, 15, 3, 41))).toEqual(-15 * minute);
+    });
+  });
+
+  describe(`polling-frequency independence`, () => {
+    const dilation = () => [new ConstantTimeDilation({ elapsed: { minutes: 0 } }, { minutes: 15 }, { minutes: 30 })];
+    const start = Date.UTC(2026, 0, 1);
+
+    it(`reaches the same offset whether polled once or every minute`, () => {
+      const coarse = buildClockAt(start, dilation());
+      jest.setSystemTime(start + 30 * minute);
+      const coarseOffset = coarse.offset;
+
+      const fine = buildClockAt(start, dilation());
+      let fineOffset = 0;
+      for (let t = 0; t <= 30 * minute; t += minute) {
+        jest.setSystemTime(start + t);
+        fineOffset = fine.offset;
+      }
+
+      expect(fineOffset).toEqual(coarseOffset);
+      expect(fineOffset).toEqual(-15 * minute);
+    });
+  });
+
+  describe(`a dilation paid back by a later compression over disjoint elapsed windows`, () => {
+    const start = Date.UTC(2026, 0, 1);
+    // 0-30min: half speed (lose 15m). 30-45min: double speed (gain 15m). Nets to zero by 45m.
+    const distortions = () => [
+      new ConstantTimeDilation({ elapsed: { minutes: 0 } }, { minutes: 15 }, { minutes: 30 }),
+      new ConstantTimeCompression({ elapsed: { minutes: 30 } }, { minutes: 30 }, { minutes: 15 }),
+    ];
+
+    it(`runs behind mid-run but returns to perfect sync by the end of the run`, () => {
+      const clock = buildClockAt(start, distortions());
+
+      jest.setSystemTime(start + 30 * minute); // dilation done, compression not yet started
+      expect(clock.relativeTimeInMillis - clock.referenceTimeInMillis).toEqual(-15 * minute);
+
+      jest.setSystemTime(start + 45 * minute); // compression has clawed it all back
+      expect(clock.relativeTimeInMillis).toEqual(clock.referenceTimeInMillis);
+    });
+  });
+});

--- a/test/ElapsedWindow.test.ts
+++ b/test/ElapsedWindow.test.ts
@@ -1,0 +1,37 @@
+import ElapsedWindow from '../src/ElapsedWindow';
+
+describe(`ElapsedWindow class`, () => {
+  const minute = 60 * 1000;
+
+  describe(`resolveAt`, () => {
+    it(`shifts the offsets by the run anchor`, () => {
+      const window = new ElapsedWindow(0, 30 * minute);
+      const anchor = 1_000_000; // arbitrary run start, in epoch millis
+
+      expect(window.resolveAt(anchor)).toEqual({ startMs: anchor, endMs: anchor + 30 * minute });
+    });
+
+    it(`is purely additive: only the anchor changes, never the span`, () => {
+      const window = new ElapsedWindow(5 * minute, 20 * minute);
+
+      // Two very different run starts produce intervals of identical length, each pinned to its
+      // own anchor -- the window is run-relative, never tied to a wall-clock instant.
+      const early = window.resolveAt(0);
+      const late = window.resolveAt(7 * 24 * 60 * minute); // a week later
+
+      expect(early).toEqual({ startMs: 5 * minute, endMs: 20 * minute });
+      expect(late.endMs - late.startMs).toEqual(early.endMs - early.startMs);
+      expect(late.startMs - early.startMs).toEqual(7 * 24 * 60 * minute);
+    });
+  });
+
+  describe(`clone`, () => {
+    it(`returns an independent, equivalent window`, () => {
+      const window = new ElapsedWindow(minute, 4 * minute);
+      const clone = window.clone();
+
+      expect(clone).not.toBe(window);
+      expect(clone.resolveAt(0)).toEqual(window.resolveAt(0));
+    });
+  });
+});

--- a/test/RelativeTimeDistortion.test.ts
+++ b/test/RelativeTimeDistortion.test.ts
@@ -1,4 +1,6 @@
 import RelativeTimeDistortion from '../src/RelativeTimeDistortion';
+import TimeWindow from '../src/TimeWindow';
+import ElapsedWindow from '../src/ElapsedWindow';
 
 describe(`RelativeTimeDistortion class`, () => {
   const start = {
@@ -30,6 +32,28 @@ describe(`RelativeTimeDistortion class`, () => {
         timewarp.getElapsedTimeInMillis(500, 2000);
         expect(distortTimeMock).toHaveBeenCalledWith(2000, 500);
       });
+    });
+  });
+
+  describe(`anchor`, () => {
+    const minute = 60 * 1000;
+
+    it(`builds a time-of-day window from a bare clock-time descriptor (the default)`, () => {
+      const timewarp = new ConcreteRelativeTimeDistortion({ hour: 1 }, { hours: 1 });
+      expect(timewarp.getTimeWindow()).toBeInstanceOf(TimeWindow);
+    });
+
+    it(`builds an elapsed window from an { elapsed } anchor`, () => {
+      const timewarp = new ConcreteRelativeTimeDistortion(
+        { elapsed: { minutes: 5 } },
+        { minutes: 10 },
+        { minutes: 20 },
+      );
+      const window = timewarp.getTimeWindow();
+
+      expect(window).toBeInstanceOf(ElapsedWindow);
+      // Spans [elapsed, elapsed + referenceDuration) = [5min, 25min) relative to the run anchor.
+      expect(window.resolveAt(0)).toEqual({ startMs: 5 * minute, endMs: 25 * minute });
     });
   });
 });


### PR DESCRIPTION
## What & why

Generalizes **where a distortion is anchored**. Until now a window was always a wall-clock
*time-of-day*; this adds a second kind — **`elapsed`** — that pins a window to the run's own
`t = 0` (the instant the `Clock` is constructed), measured in real elapsed time. This is the
engine seam the future Stopwatch/Countdown facades sit on (issue #4, step 2).

## The shape of the change

Step 1 already made `Clock` consume windows through `resolveAt(anchorMs)`, so **the offset
integrator needs no changes** — a new anchor kind is just another implementation of the same
tiny contract:

- **`DistortionWindow`** (new) — the `resolveAt` + `clone` contract; `ResolvedWindow` moves here.
- **`TimeWindow`** — now `implements DistortionWindow`; time-of-day logic untouched.
- **`ElapsedWindow`** (new) — `resolveAt(anchor) = { anchor + startOffset, anchor + endOffset }`,
  in reference (real) time.
- **`RelativeTimeDistortion`** — first constructor arg generalized to
  `DistortionAnchor = ClockTimeDescriptor | { elapsed: Duration }`, branching on
  `'elapsed' in anchor`. Also drops the unused `startClockTime` field, decouples the
  `getElapsedTimeInMillis` default length to `referenceDurationInMillis`, and extracts a
  `durationToMillis` helper.

## Design note

Elapsed windows are positioned on **real** elapsed time (only the *display* warps). This keeps
the integrator unchanged and makes "a countdown still hits zero on the real deadline" emerge for
free — placing windows on the warped timeline would make a window's bounds depend on the offset
it itself produces.

## Backward compatibility

`new ConstantTimeDilation({ hour: 1 }, { hours: 3 }, { hours: 6 })` is unchanged — a bare
descriptor still means time-of-day. The only addition is accepting `{ elapsed }` in that slot.
Public runtime exports are unchanged (the `DistortionAnchor` *type* is exported;
`ElapsedWindow`/`DistortionWindow` stay internal).

## Tests

- `ElapsedWindow` unit tests (additive resolution, independent clone).
- Clock-level elapsed-anchor tests: run-relative **regardless of calendar date**,
  polling-frequency independence, and a dilation repaid by a later compression netting to zero.
- Distortion-construction coverage (`{ elapsed }` → `ElapsedWindow`, bare descriptor →
  `TimeWindow`).
- Full suite green — **56 tests**, `tsc --noEmit` and eslint clean.

## Not in this PR

Stopwatch/Countdown facades (next step), the `absolute` anchor + multi-day spans (step 4),
`daily` recurrence, and eased distortions. No version bump (0.2.0 isn't shipped yet).

Refs #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
